### PR TITLE
Get User dto by principal (email) from access token response 200 OK | Closes #33

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -209,9 +209,8 @@ public class UserController {
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
     })
     @GetMapping
-    public ResponseEntity<UserUpdateDto> getUserByPrincipal(@ApiIgnore @AuthenticationPrincipal Principal principal) {
-        String email = principal.getName();
-        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserUpdateDtoByEmail(email));
+    public ResponseEntity<UserUpdateDto> getUserByPrincipal(@AuthenticationPrincipal String principal) {
+        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserUpdateDtoByEmail(principal));
     }
 
     /**


### PR DESCRIPTION
Environment: Firefox 116.0.3 (64-bit).
Reproducible: always.

Preconditions
Sign-in us user
Moved to Swagger http://localhost:8065/swagger-ui.html#/

Steps to reproduce

    Click on User controller
    Click on GET /user
    Click on 'Try out'

Actual result
Response 200 OK

Expected result
Response 403 Forbidden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the way user authentication information is handled for retrieving user details, resulting in a simpler and more direct process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->